### PR TITLE
Delay configuration merge

### DIFF
--- a/tasks/lib/utils.js
+++ b/tasks/lib/utils.js
@@ -1,22 +1,22 @@
 var plist = require('plist');
 
 module.exports = function(grunt) {
-    exports.generatePlist = function(target_filename, appName) {
+    exports.generatePlist = function(target_filename, appOptions) {
 
         // Handle the INfo.plist file
         var info = plist.parseFileSync(target_filename);
 
-        info.CFBundleDisplayName = appName;
-        info.CFBundleName = appName;
+        info.CFBundleDisplayName = appOptions.name;
+        info.CFBundleName = appOptions.name;
 
         info.CFBundleDocumentTypes = []; // zero out any document binding
         info.UTExportedTypeDeclarations = [];
 
-        info.CFBundleVersion = grunt.config('nodewebkit.options.app.version'); // TODO: if git, get commit hash!
-        info.CFBundleShortVersionString = 'Version ' + grunt.config('nodewebkit.options.app.version');
+        info.CFBundleVersion = appOptions.version; // TODO: if git, get commit hash!
+        info.CFBundleShortVersionString = 'Version ' + appOptions.version;
 
-        if(grunt.config('nodewebkit.options.app.copyright')) {
-          info.NSHumanReadableCopyright = grunt.config('nodewebkit.options.app.copyright');
+        if(appOptions.copyright) {
+          info.NSHumanReadableCopyright = appOptions.copyright;
         }
 
         grunt.file.write(

--- a/tasks/node_webkit_builder.js
+++ b/tasks/node_webkit_builder.js
@@ -214,7 +214,7 @@ module.exports = function(grunt) {
               if (target_filename.match(appName+'.app/Contents/Info.plist$')) {
 
                 // Generate Info.plist$
-                utils.generatePlist(target_filename, appName);
+                utils.generatePlist(target_filename, nodewebkit_cfg);
 
                 // Generate credits.html
                 if(options.credits) {


### PR DESCRIPTION
By attempting to read the package.json file before the task is invoked, you may be attempting to read a file that has not been written yet. In my project, package.json is copied from app to dist when the application is compiled, so without this change I get lots of messages like these during the build process, but then the build eventually succeeds anyway.

```
Loading "node_webkit_builder.js" tasks...ERROR
>> TypeError: Property 'verbose' of object #<Object> is not a function
Loading "node_webkit_builder.js" tasks...ERROR
>> Error: Unable to read "C:\Users\Nemu\Documents\lslim\dist\package.json" file (Error code: ENOENT).

Running "imagemin:dist" (imagemin) task
✔ app/images/glyphicons-halflings-white.png (saved -3.94 kb)
✔ app/images/glyphicons-halflings.png (saved 2.31 kB)
Minified 2 images (saved 1.81 kB)

Loading "node_webkit_builder.js" tasks...ERROR
>> TypeError: Property 'verbose' of object #<Object> is not a function
Loading "node_webkit_builder.js" tasks...ERROR
>> Error: Unable to read "C:\Users\Nemu\Documents\lslim\dist\package.json" file (Error code: ENOENT).
```

It's hard to see what's going on with the indentation change, but I've changed the code to
- no longer modify the configuration object retrieved from Grunt when merging, and to instead merge into and use a new object
- merge configuration only when the task is invoked, rather than reading files that potentially haven't been built yet
- use verbose.write instead of verbose, which is apparently not a function
