### PR TITLE
timing issue with using lazy streams for creating a mac package

### DIFF
--- a/tasks/lib/compress.js
+++ b/tasks/lib/compress.js
@@ -19,9 +19,7 @@ module.exports = function(grunt) {
         var zipDone = Q.defer(),
             destFiles = [],
             archive = archiver('zip'),
-            destStream = new Writable(function() {
-                return fs.createWriteStream(dest);
-            });
+            destStream =  fs.createWriteStream(dest);
 
         // Resolve on close
         destStream.on('finish', zipDone.resolve);
@@ -61,12 +59,8 @@ module.exports = function(grunt) {
 
     exports.generateRelease = function(relaseFile, zipPath, type, nwpath) {
         var releaseDone = Q.defer(),
-            ws = new Writable(function() {
-                return fs.createWriteStream(relaseFile);
-            }),
-            zipStream = new Readable(function() {
-                return fs.createReadStream(zipPath);
-            }),
+            ws = fs.createWriteStream(relaseFile),
+            zipStream = fs.createReadStream(zipPath),
             nwpath_rs;
 
         ws.on('error', function(err) {


### PR DESCRIPTION
Apparently using lazy streams for generating the release will cause the finish event to fire too early, which can often cause mac packaging to write only part of the destination file, creating an invalid zip.
