### PR TITLE
User system http_proxy when it is available to use

### DIFF
--- a/tasks/lib/download.js
+++ b/tasks/lib/download.js
@@ -74,7 +74,13 @@ module.exports = function(grunt) {
             extention = (url.split('.')).slice(-1)[0],
             downloadPath = path.resolve(dest, (url.split('/')).slice(-1)[0]),
             destStream = fs.createWriteStream(downloadPath),
-            downloadRequest = request(url);
+            var downloadRequest;
+
+            if(process.env.http_proxy){
+                downloadRequest = request({url: url, proxy: process.env.http_proxy});
+            }else{
+                downloadRequest = request(url);
+            }
 
         grunt.log.writeln('Downloading: ' + url);
 


### PR DESCRIPTION
The reason is, sometimes user might have proxy setup with their environment, if we ignore that, the node-webkit file wouldn't be downloaded correctly.
