### PR TITLE
Fix downloadRequest syntax error.

### DIFF
--- a/tasks/lib/download.js
+++ b/tasks/lib/download.js
@@ -74,7 +74,7 @@ module.exports = function(grunt) {
             extention = (url.split('.')).slice(-1)[0],
             downloadPath = path.resolve(dest, (url.split('/')).slice(-1)[0]),
             destStream = fs.createWriteStream(downloadPath),
-            var downloadRequest;
+            downloadRequest;
 
             if(process.env.http_proxy){
                 downloadRequest = request({url: url, proxy: process.env.http_proxy});


### PR DESCRIPTION
Version `0.1.12` introduces a syntax error:

```
$ grunt

Running "nodewebkit:src" (nodewebkit) task

/path/to/project/node_modules/grunt-node-webkit-builder/tasks/lib/download.js:77
            var downloadRequest;
            ^^^
Warning: Unexpected token var Use --force to continue.

Aborted due to warnings.
```

The following pull request helps to address it.
