### PR TITLE
Fix defer.resolve bind arguments

### DIFF
--- a/tasks/lib/download.js
+++ b/tasks/lib/download.js
@@ -62,7 +62,7 @@ module.exports = function(grunt) {
                 extractDone = exports.untarFile(data.dest, plattform.dest);
             }
 
-            extractDone.done(downloadAndUnpackDone.resolve.bind(plattform));
+            extractDone.done(downloadAndUnpackDone.resolve.bind(downloadAndUnpackDone, plattform));
 
         });
 


### PR DESCRIPTION
This was passing (undefined) as the platform and would then skip the various platform builds, requiring the task to be performed again. 
