### PR TITLE
Support app.nw folder on OS X, speeding up app boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ Default value: `https://s3.amazonaws.com/node-webkit/`
 
 The URL where the prebuilt binaries are. Only change this if you know what you are doing
 
+#### options.zip
+Type: `Boolean`
+Default value: `false`
+
+MAC ONLY: Use a `app.nw` folder instead of `ZIP` file, this significantly improves the startup speed of applications on `mac`, since no decompressing is needed. Builds on other platforms will still use `ZIP` files.
 
 ### Usage Examples
 

--- a/tasks/lib/compress.js
+++ b/tasks/lib/compress.js
@@ -48,6 +48,21 @@ module.exports = function(grunt) {
         return zipDone.promise;
     };
 
+    exports.generateFolder = function(files, dest, type) {
+        return Q.all(files.map(function(srcFile) {
+            return utils.copyFile(
+                srcFile.src,
+                path.join(
+                    dest,
+                    srcFile.dest
+                )
+            );
+        }))
+        .then(function() {
+            return type;
+        });
+    };
+
     exports.cleanUpRelease = function(nwPath) {
 
         if(grunt.file.exists(nwPath)) {

--- a/tasks/lib/utils.js
+++ b/tasks/lib/utils.js
@@ -1,6 +1,7 @@
 var plist = require('plist'),
     path = require('path'),
-    fs = require('fs');
+    fs = require('fs'),
+    Q = require('q');
 
 
 module.exports = function(grunt) {
@@ -92,6 +93,19 @@ module.exports = function(grunt) {
 
     exports.pathDepth = function(absolutePath) {
         return absolutePath.split(path.sep).length;
+    };
+
+    exports.copyFile = function(src, dest) {
+        var d = Q.defer();
+
+        try {
+            grunt.file.copy(src, dest);
+            d.resolve();
+        } catch(err) {
+            d.reject(err);
+        }
+
+        return d.promise;
     };
 
     return exports;


### PR DESCRIPTION
I added a `zip` option, that skips zipping on `OS X` if `false`. It will also avoid generating any zip, if we're only building for `mac` (if building for other platforms it will generate the ZIP file and use it for them).

I've switched this option to `false` by default, since there's no real drawbacks, except a slightly bigger `.app` folder, which is fine since it will probably be distributed through some compressed medium: `.tar.gz`, `.zip` or `.dmg`.

I'll add some quick documentation and example before merging.
