### PR TITLE
Update utils.copyFile to preserve permissions

### DIFF
--- a/tasks/lib/utils.js
+++ b/tasks/lib/utils.js
@@ -97,9 +97,10 @@ module.exports = function(grunt) {
 
     exports.copyFile = function(src, dest) {
         var d = Q.defer();
-
+        var stats = fs.lstatSync(src);
         try {
             grunt.file.copy(src, dest);
+            fs.chmodSync(dest, stats.mode);
             d.resolve();
         } catch(err) {
             d.reject(err);


### PR DESCRIPTION
Added fs.chmodSync to utils.copyFile method to preserve file permissions when creating app folder.
