### PR TITLE
Mac extended plist options

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ Default value: `false`
 
 MAC ONLY: The path to your credits.html file. If your don't provide your own it will use the one provided by node-webkit
 
+#### options.mac_bundle_id
+Type: `String`
+Default value: same as node-webkit downloaded prebuilt binary
+
+MAC ONLY: CFBundleIdentifier key for Info.plist
+
 #### options.mac_icns
 Type: `String`
 Default value: `false`

--- a/tasks/lib/utils.js
+++ b/tasks/lib/utils.js
@@ -12,6 +12,9 @@ module.exports = function(grunt) {
         var info = plist.parseFileSync(abspath);
         info.CFBundleDisplayName = options.app_name;
         info.CFBundleName = options.app_name;
+        if(options.mac_bundle_id) {
+            info.CFBundleIdentifier = options.mac_bundle_id
+        }
 
         info.CFBundleDocumentTypes = options.mac_document_types.map(function(type) {
             return {

--- a/tasks/node_webkit_builder.js
+++ b/tasks/node_webkit_builder.js
@@ -39,6 +39,7 @@ module.exports = function(grunt) {
           mac: true,
           linux32: false,
           linux64: false,
+          mac_bundle_id: null,
           mac_icns: false,
           mac_document_types: [],
           download_url: 'https://s3.amazonaws.com/node-webkit/',


### PR DESCRIPTION
Additional config options for Info.plist generation (mac)

options.mac_bundle_id — allows OS properly assign file associations
options.mac_document_types — for describing the document types the application can open
