### PR TITLE
If timestamped_builds is false we should append the app's version number...

### DIFF
--- a/tasks/node_webkit_builder.js
+++ b/tasks/node_webkit_builder.js
@@ -112,7 +112,7 @@ module.exports = function(grunt) {
     var release_path = path.resolve(
       options.build_dir,
       'releases',
-      options.app_name + (options.timestamped_builds ?  ' - ' + Math.round(Date.now() / 1000).toString() : '')
+      options.app_name + (options.timestamped_builds ?  ' - ' + Math.round(Date.now() / 1000).toString() : ' - ' + options.app_version)
     );
 
     // Get the Path for the releaseFile


### PR DESCRIPTION
... instead.

The readme states that timestamped_builds "Enables the creation of release directories named with a timestamp instead of the app_version." However, when false the app_version is not being appended to the directory name.
