### PR TITLE
improve untar speed x100

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,13 +51,13 @@
     "request": "~2.33.0",
     "unzip": "~0.1.9",
     "async": "~0.2.9",
-    "tar": "~0.1.19",
     "lazystream": "~0.1.0",
     "archiver": "~0.5.2",
     "zip": "~1.1.1",
     "plist": "~0.4.3",
     "q": "~1.0.0",
     "lodash": "~2.4.1",
-    "request-progress": "~0.3.1"
+    "request-progress": "~0.3.1",
+    "ext-tar": "~0.1.1"
   }
 }

--- a/tasks/lib/download.js
+++ b/tasks/lib/download.js
@@ -1,6 +1,6 @@
 var fs = require('fs'),
     Q = require('q'),
-    tar = require('tar'),
+    tar = require('ext-tar').tar,
     zlib = require('zlib'),
     path = require('path'),
     request = require('request'),
@@ -185,22 +185,17 @@ module.exports = function(grunt) {
 
     exports.untarFile = function(file, dest) {
         var untarDone = Q.defer();
-
-        fs.createReadStream(file)
-            .pipe(zlib.createGunzip())
-            .pipe(tar.Extract({
-                path: dest,
-                strip: 1
-            }))
-            .on('error', function(error) {
-                grunt.log.error('There was an error untaring the file', error);
-            })
-            .on('end', untarDone.resolve)
-            .on("entry", function(entry) {
-                var filename = entry.path.split('/').reverse()[0];
-                grunt.verbose.writeln('Unpacking ' + filename + ' --> ' + path.resolve(dest, filename));
+        tar.extract(file, dest, function (err, code) {
+            if (err) return untarDone.reject(err);
+            var basename = path.basename(file, '.tar.gz');
+            fs.readdir(path.join(dest, basename), function (err, files) {
+                for (var i = 0; i < files.length; i++) {
+                    fs.renameSync(path.join(dest, basename, files[i]), path.join(dest, files[i]));
+                }
+                fs.rmdirSync(path.join(dest, basename));
+                untarDone.resolve();
             });
-
+        });
         return untarDone.promise;
     };
 


### PR DESCRIPTION
I made new npm package (ext-tar) to improve making linux apps. It invokes external tar command (on Windows, it uses bundled TarTool.exe) to extract. It reduces 99% user time.

Before

``` sh
$ time grunt
Running "nodewebkit:src" (nodewebkit) task
Downloading: http://dl.node-webkit.org/v0.9.2/node-webkit-v0.9.2-linux-ia32.tar.gz
Downloading: http://dl.node-webkit.org/v0.9.2/node-webkit-v0.9.2-linux-x64.tar.gz
/Users/shibukawa.yoshiki/develop/grunt-node-webkit-builder/example/build/releases/nw-demo/linux32/nw-demo/nw-demo /Users/shibukawa.yoshiki/develop/grunt-node-webkit-builder/example/build/releases/nw-demo/nw-demo.nw linux32 /Users/shibukawa.yoshiki/develop/grunt-node-webkit-builder/example/build/cache/linux32/0.9.2/nw
/Users/shibukawa.yoshiki/develop/grunt-node-webkit-builder/example/build/releases/nw-demo/linux64/nw-demo/nw-demo /Users/shibukawa.yoshiki/develop/grunt-node-webkit-builder/example/build/releases/nw-demo/nw-demo.nw linux64 /Users/shibukawa.yoshiki/develop/grunt-node-webkit-builder/example/build/cache/linux64/0.9.2/nw
>> Created a new release with node-webkit (0.9.2) for linux32, linux64
>> @ /Users/shibukawa.yoshiki/develop/grunt-node-webkit-builder/example/build/releases/nw-demo

Done, without errors.

real    6m40.057s
user    4m57.344s
sys 0m21.423s
```

After:

``` sh
$ time grunt
Running "nodewebkit:src" (nodewebkit) task
Downloading: http://dl.node-webkit.org/v0.9.2/node-webkit-v0.9.2-linux-ia32.tar.gz
Downloading: http://dl.node-webkit.org/v0.9.2/node-webkit-v0.9.2-linux-x64.tar.gz
/Users/shibukawa.yoshiki/develop/grunt-node-webkit-builder/example/build/releases/nw-demo/linux32/nw-demo/nw-demo /Users/shibukawa.yoshiki/develop/grunt-node-webkit-builder/example/build/releases/nw-demo/nw-demo.nw linux32 /Users/shibukawa.yoshiki/develop/grunt-node-webkit-builder/example/build/cache/linux32/0.9.2/nw
/Users/shibukawa.yoshiki/develop/grunt-node-webkit-builder/example/build/releases/nw-demo/linux64/nw-demo/nw-demo /Users/shibukawa.yoshiki/develop/grunt-node-webkit-builder/example/build/releases/nw-demo/nw-demo.nw linux64 /Users/shibukawa.yoshiki/develop/grunt-node-webkit-builder/example/build/cache/linux64/0.9.2/nw
>> Created a new release with node-webkit (0.9.2) for linux32, linux64
>> @ /Users/shibukawa.yoshiki/develop/grunt-node-webkit-builder/example/build/releases/nw-demo

Done, without errors.

real    1m45.939s
user    0m3.540s
sys 0m2.040s
```
