### PR TITLE
Updated archiver to 0.9.0 to fix failure on Jenkins CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "gruntplugin"
   ],
   "dependencies": {
-    "archiver": "~0.5.2",
+    "archiver": "~0.9.0",
     "async": "~0.2.9",
     "lazystream": "~0.1.0",
     "lodash": "~2.4.1",


### PR DESCRIPTION
archiver depends on file-utils which depends on isbinaryfile.
Currently used version of isbinaryfile fails on Jekins CI because of: https://github.com/gjtorikian/isBinaryFile/issues/10

This was fixed in the newest version of isbinaryfile. Other libraries: file-utils and archiver already caught up.

I've tested this change using OS X 10.7, 10.8, 10.9 and Windows 7 (64 bit): builds work as expected.
