### PR TITLE
Optional options.cache_dir to specify location for prebuilt downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,13 @@ The version of your node-webkit app.
 Type: `String`
 Default value: `null`
 
-This is where the prebuilt binaries and the releases are saved.
+This is where the releases are saved.
+
+#### options.cache_dir
+Type: `String`
+Default value: `[options.build_dir]/cache`
+
+This is where the cached node-webkit downloads are saved.
 
 #### options.force_download
 Type: `Boolean`

--- a/tasks/node_webkit_builder.js
+++ b/tasks/node_webkit_builder.js
@@ -34,6 +34,7 @@ module.exports = function(grunt) {
           app_name: null,
           app_version: null,
           build_dir: null, // Path where
+          cache_dir: null, // 
           force_download: false,
           win: true,
           mac: true,
@@ -85,6 +86,8 @@ module.exports = function(grunt) {
       grunt.log.warn("No platforms to build!");
       return done();
     }
+
+    var cacheDir = (options.cache_dir !== null) ? options.cache_dir : path.resolve(options.build_dir, 'cache');
 
     // Process the files array
     var filesInfo = utils.getFileList(this.files),
@@ -138,8 +141,7 @@ module.exports = function(grunt) {
         plattform.app = plattform.app.split('%APPNAME%').join(options.app_name);
         plattform.nwpath = plattform.nwpath.split('%APPNAME%').join(options.app_name);
         plattform.dest = path.resolve(
-          options.build_dir,
-          'cache',
+          cacheDir,
           plattform.type,
           options.version
         );


### PR DESCRIPTION
This is a quick tweak to grunt-node-webkit-builder to allow explicitly setting the cache location. If unspecified, it continues to default to cache within options.build_dir as before.
