### PR TITLE
fix path to Mac icon

### DIFF
--- a/example/Gruntfile.js
+++ b/example/Gruntfile.js
@@ -5,7 +5,7 @@ module.exports = function(grunt) {
       options: {
         build_dir: './build', // Where the build version of my node-webkit app is saved
         credits: './public/credits.html',
-        mac_icns: './example/icon.icns', // Path to the Mac icon file
+        mac_icns: './icon.icns', // Path to the Mac icon file
         mac: true, // We want to build it for mac
         win: false, // We want to build it for win
         linux32: false, // We don't need linux32


### PR DESCRIPTION
The icon path is not correct in the sample app, so you don't see the Grunt boar icon, and instead you see the default node-webkit icon.  This fixes that.
