### PR TITLE
Old options style fix

### DIFF
--- a/tasks/node_webkit_builder.js
+++ b/tasks/node_webkit_builder.js
@@ -22,6 +22,7 @@ module.exports = function(grunt) {
       // maintain backward compatibility by supporting old platform style
       switch(opt){
         case 'win':
+        case 'osx':
         case 'linux32':
         case 'linux64':
           if(!!options[opt]) {


### PR DESCRIPTION
Hi,
with the `v0.2.0` update a new style of task options was introduced. With the old style, all platforms were being built, although some might have been set to `false`. Here is a fix which checks for platforms being set to `true`.
I've also added the `osx` platform type to prevent potential confusion.
