### PR TITLE
Update node-webkit-builder dependency to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "node-webkit"
   ],
   "dependencies": {
-    "node-webkit-builder": "^0.3.0"
+    "node-webkit-builder": "^0.x"
   },
   "devDependencies": {
     "grunt": "^0.4.4"


### PR DESCRIPTION
Seems like someone forgot to update the version field of the `node-webkit-builder` dependency in the `package.json` to `0.3.0`. Currently it gets version `0.1.4` of `node-webkit-builder` when installing this grunt plugin.
