### PR TITLE
Properly handle zip option for nw-builder v2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "application"
   ],
   "dependencies": {
-    "nw-builder": "^2.0.0"
+    "nw-builder": "^2.2.0"
   },
   "devDependencies": {
     "grunt": "^0.4.4"

--- a/tasks/node_webkit_builder.js
+++ b/tasks/node_webkit_builder.js
@@ -56,8 +56,11 @@ module.exports = function(grunt) {
           break;
 
         case 'credits':
+          nwOptions['macCredits'] = options[opt];
+          break;
+
         case 'zip':
-          nwOptions[toCamelcase('mac_'+opt)] = options[opt];
+          nwOptions['zip'] = options[opt];
           break;
 
         default:


### PR DESCRIPTION
Saw that you merged the zip option for nw-builder in v2.2.0 and would like to help surface that in grunt-nw-builder.