### PR TITLE
change tilde to caret to have the newest new-build version in the frame of the major version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "application"
   ],
   "dependencies": {
-    "nw-builder": "~3.1.0"
+    "nw-builder": "^3.1.0"
   },
   "devDependencies": {
     "grunt": "^1.0.1"


### PR DESCRIPTION
…me of the major version number

Currently, grunt-nw-builder based on nw-builder "version": "3.1.3" it makes unavailable a newest cool features implemented in nw-builder 3.5.7