### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-nw-builder",
   "description": "Let's you build your node webkit apps with grunt",
-  "version": "3.1.0",
+  "version": "3.5.7",
   "homepage": "https://github.com/mllrsohn/grunt-nw-builder",
   "author": {
     "name": "Steffen Müller",
@@ -20,10 +20,10 @@
   "license": "MIT",
   "main": "Gruntfile.js",
   "engines": {
-    "node": ">= 4.0.0"
+    "node": ">= 8.0.0"
   },
   "peerDependencies": {
-    "grunt": "^1.0.1"
+    "grunt": "^1.4.1"
   },
   "keywords": [
     "gruntplugin",
@@ -36,9 +36,9 @@
     "application"
   ],
   "dependencies": {
-    "nw-builder": "~3.1.0"
+    "nw-builder": "^3.5.7"
   },
   "devDependencies": {
-    "grunt": "^1.0.1"
+    "grunt": "^1.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "node": ">= 8.0.0"
   },
   "peerDependencies": {
-    "grunt": "^1.4.1"
+    "grunt": "^1.5.3"
   },
   "keywords": [
     "gruntplugin",
@@ -39,6 +39,6 @@
     "nw-builder": "3.6.0"
   },
   "devDependencies": {
-    "grunt": "^1.4.1"
+    "grunt": "1.5.3"
   }
 }


### PR DESCRIPTION
This updates grunt and nw-builder, which fixes lots of bugs. It increases the minimum node version required because grunt started requiring at least node v8, but I think it's good to have that updated. If we want to preserve support for versions 4, 5, 6, and 7, we can move the grunt dependency back to 1.0.4 and still benefit from some bug fixes.