### PR TITLE
fix: set `options.srcDir` to `this.data.src`

### DIFF
--- a/tasks/nw.js
+++ b/tasks/nw.js
@@ -6,7 +6,7 @@ module.exports = function (grunt) {
       const done = this.async();
       const options = this.options();
       // Set options.srcDir via the Grunt task's src option:
-      options.srcDir = this.data;
+      options.srcDir = this.data.src;
 
       let nwbuild = undefined;
 


### PR DESCRIPTION
srcDir is currently set to the entire task object.